### PR TITLE
:green_heart: Fixed build test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ x64/
 build*/
 cmake*/
 .idea/
+.vscode/
 
 # Auto installed libraries
 vendors/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ ExternalProject_Add(
         GIT_REPOSITORY https://github.com/google/googletest.git
         GIT_TAG v1.16.x
         PREFIX ./vendors
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DBUILD_GMOCK=OFF
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 
-set(VENDORS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vendors CACHE STRING "Vendors directory")
+set(VENDORS_DIR ${CMAKE_BINARY_DIR}/vendors CACHE STRING "Vendors directory")
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release" FORCE)
@@ -30,7 +30,7 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Choose the type of b
 
 set(NARC_VERSION_MAJOR "0")
 set(NARC_VERSION_MINOR "1")
-set(NARC_VERSION_PATCH "0")
+set(NARC_VERSION_PATCH "1")
 set(NARC_VERSION "${NARC_VERSION_MAJOR}.${NARC_VERSION_MINOR}.${NARC_VERSION_PATCH}")
 
 project(NarcEngineApp VERSION ${NARC_VERSION})

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TEST_CPP_FILES ${CPP_FILES})
 list(REMOVE_ITEM TEST_CPP_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
 add_executable(NarcEngineEditor_Tests tests/test_main.cpp ${TEST_CPP_FILES} ${HPP_FILES})
 
-add_dependencies(NarcEngineEditor
+add_dependencies(NarcEngineEditor_Tests
         googleTest
         NarcEngine)
 


### PR DESCRIPTION
This pull request includes several changes to the build configuration in `CMakeLists.txt` files to improve the project setup and dependency management. The most important changes involve modifying the `ExternalProject_Add` configuration, updating the vendors directory path, and correcting the dependency for the test executable.

Changes to `CMakeLists.txt`:

* Removed the `-DBUILD_GMOCK=OFF` argument from the `CMAKE_ARGS` in the `ExternalProject_Add` configuration for the googletest repository.
* Updated the `VENDORS_DIR` to use `${CMAKE_BINARY_DIR}` instead of `${CMAKE_CURRENT_SOURCE_DIR}` for the vendors directory path.
* Incremented the `NARC_VERSION_PATCH` from "0" to "1".

Changes to `application/CMakeLists.txt`:

* Corrected the `add_dependencies` for `NarcEngineEditor_Tests` to ensure it depends on `googleTest` and `NarcEngine` instead of `NarcEngineEditor`.